### PR TITLE
Patch GMS

### DIFF
--- a/R/GMS.R
+++ b/R/GMS.R
@@ -32,6 +32,18 @@ GMS <- function(label = "GMS",
 
   questionnaire_id <- "GMS"
 
+  dots <- list(...)
+  if (is.null(dots$style_params)) {
+    style_params <- NULL
+  } else {
+    style_params <- dots$style_params
+  }
+  if (is.null(dots$with_prompt_head)) {
+    with_prompt_head <- FALSE
+  } else {
+    with_prompt_head <- dots$with_prompt_head
+  }
+
   main_test_gms(
     questionnaire_id = questionnaire_id,
     label = label,
@@ -41,7 +53,8 @@ GMS <- function(label = "GMS",
                       configuration_filepath = configuration_filepath),
     subscales = subscales,
     dict = dict,
-    ...
+    with_prompt_head = with_prompt_head,
+    style_params = style_params
   )
 }
 

--- a/R/GMS.R
+++ b/R/GMS.R
@@ -40,11 +40,12 @@ GMS <- function(label = "GMS",
                       short_version = short_version,
                       configuration_filepath = configuration_filepath),
     subscales = subscales,
-    dict = dict
+    dict = dict,
+    ...
   )
 }
 
-main_test_gms <- function(questionnaire_id, label, items, subscales, dict) {
+main_test_gms <- function(questionnaire_id, label, items, subscales, dict, with_prompt_head = FALSE, style_params = NULL) {
   elts <- c()
   prompt_id <- NULL
   prompt_ids <- items %>% pull(prompt_id)
@@ -92,7 +93,9 @@ main_test_gms <- function(questionnaire_id, label, items, subscales, dict) {
         prompt = get_prompt(
           counter,
           length(question_numbers),
-          sprintf("T%s_%04d_PROMPT", questionnaire_id, question_numbers[counter])
+          sprintf("T%s_%04d_PROMPT", questionnaire_id, question_numbers[counter]),
+          with_prompt_head = with_prompt_head,
+          style_params = style_params
         ),
         choices = choices,
         arrange_vertically = arrange_vertically,


### PR DESCRIPTION
`GMS()` didn't pass `style_params` to `get_prompt()` in `gms_main_test()`.
Now you can use `style_params = list(with_counter = FALSE)` to hide the page counter.